### PR TITLE
refactor: できたこと・記事ストックの「メモ」、目標の「内容」入力枠の横方向リサイズを禁止。

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -372,7 +372,8 @@ option:focus-visible {
 .input-done-memo-area,
 .input-goal-content-area,
 .input-article-memo-area {
-  height: 100px;
+  min-height: 100px;
+  resize: vertical;
   margin-top: 1px;
   padding-top: 10px;
   font-family: var(--normal-font-set);


### PR DESCRIPTION
close #107 
できたこと・記事ストックの「メモ」、目標の「内容」の入力枠（textarea）を縦方向にのみ伸ばせるようにし、横方向のリサイズを禁止。
また、縦方向のリサイズも高さ設定をmin-heightに変更し、縮めても枠が潰れないように修正。