### PR TITLE
refactor: 記事ストックのタグリレーション削除SQLを修正。タグリレーション更新の条件分岐を修正。

### DIFF
--- a/src/main/java/webapp/AwesomeCollect/mapper/junction/ArticleTagJunctionMapper.java
+++ b/src/main/java/webapp/AwesomeCollect/mapper/junction/ArticleTagJunctionMapper.java
@@ -11,7 +11,7 @@ import webapp.AwesomeCollect.provider.ActionTagJunctionProvider;
 import webapp.AwesomeCollect.provider.param.JunctionDeleteParams;
 
 @Mapper
-public interface ArticleTagsJunctionMapper extends BaseActionTagJunctionMapper<ArticleTagJunction> {
+public interface ArticleTagJunctionMapper extends BaseActionTagJunctionMapper<ArticleTagJunction> {
 
   @Select("""
       SELECT tag_id FROM article_tag
@@ -41,7 +41,7 @@ public interface ArticleTagsJunctionMapper extends BaseActionTagJunctionMapper<A
 
   @Delete("""
       DELETE FROM article_tag
-      WHERE article_tag=#{articleId} AND tag_id=#{tagId}
+      WHERE article_id=#{articleId} AND tag_id=#{tagId}
       """)
   void deleteRelationByRelatedId(ArticleTagJunction relation);
 

--- a/src/main/java/webapp/AwesomeCollect/repository/junction/ArticleTagJunctionRepository.java
+++ b/src/main/java/webapp/AwesomeCollect/repository/junction/ArticleTagJunctionRepository.java
@@ -3,7 +3,7 @@ package webapp.AwesomeCollect.repository.junction;
 import java.util.List;
 import org.springframework.stereotype.Repository;
 import webapp.AwesomeCollect.entity.junction.ArticleTagJunction;
-import webapp.AwesomeCollect.mapper.junction.ArticleTagsJunctionMapper;
+import webapp.AwesomeCollect.mapper.junction.ArticleTagJunctionMapper;
 import webapp.AwesomeCollect.provider.param.JunctionDeleteParams;
 
 /**
@@ -12,7 +12,7 @@ import webapp.AwesomeCollect.provider.param.JunctionDeleteParams;
 @Repository
 public class ArticleTagJunctionRepository extends BaseActionTagJunctionRepository<ArticleTagJunction> {
 
-  public ArticleTagJunctionRepository(ArticleTagsJunctionMapper mapper) {
+  public ArticleTagJunctionRepository(ArticleTagJunctionMapper mapper) {
     super(mapper);
   }
 

--- a/src/main/java/webapp/AwesomeCollect/service/junction/BaseActionTagJunctionService.java
+++ b/src/main/java/webapp/AwesomeCollect/service/junction/BaseActionTagJunctionService.java
@@ -1,5 +1,6 @@
 package webapp.AwesomeCollect.service.junction;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -64,11 +65,15 @@ public abstract class BaseActionTagJunctionService<T> {
       int actionId, BiFunction<Integer, Integer, T> relationFactory,
       List<Integer> tagIdList) {
 
-    if (tagIdList == null || tagIdList.isEmpty()) {
-      return;
-    }
-
     List<Integer> currentTagIdList = prepareTagIdListByActionId(actionId);
+
+    if (tagIdList == null) {
+      if (currentTagIdList == null || currentTagIdList.isEmpty()) {
+        return;
+      } else {
+        tagIdList = Collections.emptyList();
+      }
+    }
     registerRelations(actionId, relationFactory, tagIdList, currentTagIdList);
     deleteRelations(actionId, relationFactory, tagIdList, currentTagIdList);
   }


### PR DESCRIPTION
close #111 , close #112 
- 記事ストックのタグリレーション削除SQLのうち、WHERE指定のCOLUMN名が間違っていたので修正
- タグリレーション更新の条件分岐を入力タグがnullの場合スキップ→入力タグがnullかつ既存タグなしの場合スキップに変更