### PR TITLE
refactor: UI修正を想定して1年キャッシュは画像のみにし、CSSとJSは半日キャッシュに変更。

### DIFF
--- a/src/main/java/webapp/AwesomeCollect/config/WebConfig.java
+++ b/src/main/java/webapp/AwesomeCollect/config/WebConfig.java
@@ -10,10 +10,25 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
+  private static final String IMAGE = "/static/images/";
+  private static final String CSS = "/static/css/";
+  private static final String JS = "/static/js/";
+
+  private static final String ROOT_ALL_FILE = "**";
+  private static final String CLASSPATH = "classpath:";
+
+  private static final int ONE_YEAR = 31536000;
+  private static final int HALF_DAY = 3600 * 12;
+
+  // 画像は1年、CSSとJSは半日キャッシュ
   @Override
   public void addResourceHandlers(ResourceHandlerRegistry registry) {
-    registry.addResourceHandler("/static/**")
-        .addResourceLocations("classpath:/static/")
-        .setCachePeriod(31536000);
+    registry.addResourceHandler(IMAGE + ROOT_ALL_FILE)
+        .addResourceLocations(CLASSPATH + IMAGE)
+        .setCachePeriod(ONE_YEAR);
+
+    registry.addResourceHandler(CSS + ROOT_ALL_FILE, JS + ROOT_ALL_FILE)
+        .addResourceLocations(CLASSPATH + CSS, CLASSPATH + JS)
+        .setCachePeriod(HALF_DAY);
   }
 }


### PR DESCRIPTION
- キャッシュ期間を画像は1年（変更なし）、CSSとJSは半日に変更
- ファイルディレクトリやキャッシュ期間を定数化し、マジックナンバーを除去。