### PR TITLE
refactor: トップページのタイトル変更が漏れていたので修正。

### DIFF
--- a/src/main/resources/templates/top.html
+++ b/src/main/resources/templates/top.html
@@ -3,7 +3,7 @@
 
   <head>
     <meta charset="UTF-8">
-    <title>ホーム</title>
+    <title>トップ・メインメニュー</title>
     <link rel="stylesheet" th:href="@{/css/style.css}">
   </head>
 


### PR DESCRIPTION
トップページのタイトルをホーム→トップ・メインメニューに変更。