### PR TITLE
refactor: 記事ストックの一覧画面からURLの行をなくし、タイトルをaタグにして直接リンクにした。

### DIFF
--- a/src/main/resources/templates/article_stock.html
+++ b/src/main/resources/templates/article_stock.html
@@ -51,20 +51,14 @@
               <table class="view-table">
                 <tr>
                   <th scope="row" class="view-row-th">記事タイトル</th>
-                  <td th:text="${articleStock.title}"></td>
-                  <td rowspan="4" class="detail-link-td">
+                  <td class="url-area">
+                    <a th:href="${articleStock.url}" th:text="${articleStock.title}"></a>
+                  </td>
+                  <td rowspan="3" class="detail-link-td">
                     <div class="detail-link-area">
                       <a th:href="@{/article_stock/detail/{id}(id=${articleStock.id})}"
                          class="detail-link-button">詳細</a>
                     </div>
-                  </td>
-                </tr>
-                <tr>
-                  <th scope="row" class="view-row-th">URL</th>
-                  <td class="url-area">
-                    <a th:href="${articleStock.url}">
-                      <div th:text="${articleStock.url}"></div>
-                    </a>
                   </td>
                 </tr>
                 <tr>

--- a/src/main/resources/templates/article_stock/detail.html
+++ b/src/main/resources/templates/article_stock/detail.html
@@ -57,9 +57,7 @@
             <tr>
               <th scope="row" class="view-row-th">URL</th>
               <td class="url-area">
-                <a th:href="${articleResponseDto.url}">
-                  <div th:text="${articleResponseDto.url}"></div>
-                </a>
+                <a th:href="${articleResponseDto.url}" th:text="${articleResponseDto.url}"></a>
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
- 記事ストックの一覧画面からURL欄を削除
- タイトルをaタグにして直接リンクに
- 詳細画面のURL欄がaタグでdivタグを囲んでテキスト表示をしていたので、aタグにテキストを含める形に変更