### PR TITLE
refactor: メモ編集フォームにもEnter移動を反映。

### DIFF
--- a/src/main/resources/static/js/move-focus-on-enter.js
+++ b/src/main/resources/static/js/move-focus-on-enter.js
@@ -25,17 +25,22 @@ function enableEnterToNextField(formSelector) {
 
                 const next = inputField[index + 1];
                 if (next) {
-                    // タグ入力欄はTagify.DOM.inputに変換されるため別出しで処理する。
+                    // 次のフィールドのクラスが"tags-input"の場合はtagify入力欄にフォーカスする。
                     if (next.classList.contains('tags-input')) {
                         const tagify = tagifyMap.get(next);
                         if (tagify && tagify.DOM && tagify.DOM.input) {
                             tagify.DOM.input.focus();
-                        } else {
-                            next.focus();
+                            return;
                         }
-                    } else {
-                        next.focus();
                     }
+
+                    // 次のフィールドのidが"content"でeasyMDEが存在する場合はeasyMDEエディタにフォーカスする。
+                    if (next.id === 'content' && typeof easyMDE !== 'undefined') {
+                        easyMDE.codemirror.focus();
+                        return;
+                    }
+
+                    next.focus();
                 } else {
                     const submitButton = form.querySelector('button[type="submit"]');
                     if (submitButton) submitButton.click();

--- a/src/main/resources/templates/memo/detail/edit.html
+++ b/src/main/resources/templates/memo/detail/edit.html
@@ -96,6 +96,14 @@
           <button type="submit" class="register-button">登録</button>
         </div>
       </form>
+
+      <!-- Enter押下時に次のフィールドに移動する関数を呼び出す -->
+      <script th:src="@{/js/move-focus-on-enter.js}"></script>
+      <script th:inline="javascript">
+        document.addEventListener('DOMContentLoaded', () => {
+            enableEnterToNextField('#targetForm');
+        });
+      </script>
     </div>
 
     <!-- EasyMDEの設定を呼び出す -->


### PR DESCRIPTION
メモ編集フォームでもEnterで次のフィールドに移動できるように修正。
ただし、メモ編集フォームはinput: title, textarea: content, input: tagの構成のため、実質title→contentの移動のみ有効。